### PR TITLE
회원 유형 선택 페이지 : 접근 권한에 따른 분기 처리

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -16,6 +16,7 @@ import ReviewWritePage from './pages/review/write'
 import SignupStartPage from './pages/signup'
 import SignupEndPage from './pages/signup/end'
 import SignupPage from './pages/signup/signup'
+import SelectPlanRouter from './router/SelectPlanRouter'
 
 export default function AppRouter() {
   return (
@@ -29,7 +30,9 @@ export default function AppRouter() {
         <Route path="/result" element={<div>result page</div>} />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/signup/end" element={<SignupEndPage />} />
-        <Route path="/select-plan" element={<SelectPlanPage />} />
+        <Route element={<SelectPlanRouter />}>
+          <Route path="/select-plan" element={<SelectPlanPage />} />
+        </Route>
         {/* <Route path="/browsing" element={<BrowsingPage />} /> */}
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/mypage/edit" element={<MyPageEditPage />} />

--- a/src/pages/login/components/confirm-page/index.tsx
+++ b/src/pages/login/components/confirm-page/index.tsx
@@ -1,4 +1,5 @@
 import { SheetSliceState, sheet } from '@/store/sheet-slice'
+import { user } from '@/store/user-slice'
 
 import RectangleButton from '@components/rectangle-button'
 import { useDispatch, useSelector } from 'react-redux'
@@ -15,6 +16,7 @@ const ConfirmPage = () => {
 
   const handleCreateAccount = () => {
     navigate('/')
+    dispatch(user({ newUser: false }))
   }
 
   return (

--- a/src/pages/login/login/index.tsx
+++ b/src/pages/login/login/index.tsx
@@ -1,19 +1,23 @@
+import { useState } from 'react'
+
 import { postLogin } from '@/api/authAPI'
 import { useFormValidation } from '@/hooks/useFormValidation'
+import { user } from '@/store/user-slice'
 import isAxiosError from '@/utils/isAxiosError'
 import { saveTokens } from '@/utils/tokenStorage'
 import useKeyboardDetection from '@/utils/useKeyboardDetection'
 import { loginEmailValidate, loginPasswordValidate } from '@/utils/validate'
-import { useState } from 'react'
 
 import FormContainer from '@components/form-container'
 import Input from '@components/input'
 import { Controller, useForm } from 'react-hook-form'
+import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import type { IErrorResponse, IFormData } from './Login.type'
 
 export default function LoginPage() {
+  const dispatch = useDispatch()
   const isKeyboardOpen = useKeyboardDetection()
   const navigate = useNavigate()
   const {
@@ -44,6 +48,7 @@ export default function LoginPage() {
       const response = await postLogin(data)
       const { accessToken, refreshToken } = response.data.token
       const { newUser } = response.data
+      dispatch(user({ newUser: newUser }))
       saveTokens(accessToken, refreshToken)
       if (newUser) {
         navigate('/select-plan')

--- a/src/router/SelectPlanRouter.tsx
+++ b/src/router/SelectPlanRouter.tsx
@@ -1,0 +1,17 @@
+import { UserSliceState } from '@/store/user-slice'
+
+import { useSelector } from 'react-redux'
+import { Navigate, Outlet } from 'react-router-dom'
+
+const SelectPlanRouter = () => {
+  const sheetReducer = useSelector((state: UserSliceState) => state.user.value)
+  const { newUser } = sheetReducer
+
+  if (newUser) {
+    return <Outlet />
+  } else {
+    return <Navigate to="/" />
+  }
+}
+
+export default SelectPlanRouter

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,15 +12,17 @@ import {
 import storage from 'redux-persist/lib/storage'
 
 import { sheetSlice } from './sheet-slice'
+import { userSlice } from './user-slice'
 
 const reducers = combineReducers({
   sheet: sheetSlice.reducer,
+  user: userSlice.reducer,
 })
 
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['sheet'],
+  whitelist: ['sheet', 'user'],
 }
 
 const persistedReducer = persistReducer(persistConfig, reducers)

--- a/src/store/user-slice.ts
+++ b/src/store/user-slice.ts
@@ -1,0 +1,22 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+export interface UserSliceState {
+  user: {
+    value: {
+      newUser: boolean
+    }
+  }
+}
+
+export const userSlice = createSlice({
+  name: 'user',
+  initialState: { value: { newUser: false } },
+  reducers: {
+    user: (state, action) => {
+      state.value = action.payload
+    },
+    reset: () => {},
+  },
+})
+
+export const { user, reset } = userSlice.actions


### PR DESCRIPTION
## #️⃣ PR 타입

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정(디자인 등)

## 📝 작업 내용/변경 사항
📌 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) 
> - 회원 유형 선택 페이지 라우터 관리 #104 
> - newUser 상태를 리덕스로 관리
>    - 최초 로그인 시에만 /select-plan에 접근 가능
>    - 재로그인 유저가 /select-plan 접근 시, / 로 리다이렉트 시킴
>    - 또한, 이미 신규 유저라도 이미 회원 유형을 선택했다면, 리덕스 newUser 값을 false로 바꿔 /select-plan에 접근 불가능하게 함

### 스크린샷 (선택)
| 기능 | 스크린샷 |
| --- | --- |
|  | <img src = "" width ="250">  |


## 💬 리뷰 요구사항(선택)
📌 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> -
> -

##  💭 연관된 이슈(선택)
📌 #이슈번호
