### PR TITLE
default image, 리뷰 사진, 추천 상품 

### DIFF
--- a/src/components/image-carousel/index.tsx
+++ b/src/components/image-carousel/index.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react'
 
 import nextIcon from '@/assets/home/next.svg'
 import previousIcon from '@/assets/home/previous.svg'
+import defaultImage from '@/assets/login/airplane.png'
 
 import * as S from './ImageCarousel.styles.tsx'
 
 import type { IImageCarousel } from './ImageCarousel.type.ts'
 
-const ImageCarousel = ({ images, limit }: IImageCarousel) => {
+const ImageCarousel = ({ images = [defaultImage], limit }: IImageCarousel) => {
   const [currentIndex, setCurrentIndex] = useState(0)
 
   const handlePrevClick = () => {

--- a/src/components/product-card/ProductCard.style.tsx
+++ b/src/components/product-card/ProductCard.style.tsx
@@ -24,6 +24,8 @@ export const CardImage = styled.img<SizeProps>`
     width: ${size === 'sm' || size === 'summary' ? '10.2rem' : '100%'};
     height: ${size === 'sm' || size === 'summary' ? '10.2rem' : '15.2rem'};
   `}
+  border-radius: 0.5rem;
+  object-fit: cover;
 `
 
 export const ContentsWrapper = styled.div`

--- a/src/components/product-card/index.tsx
+++ b/src/components/product-card/index.tsx
@@ -6,6 +6,7 @@ import { LOCALE_CODE_LIST } from '@/constants/FILTERING_BROWSING'
 import { registerRecentProducts } from '@/utils/registerLocalStorage'
 
 import BookmarkButton from '@components/bookmark-button'
+import { useNavigate } from 'react-router-dom'
 
 import * as S from './ProductCard.style'
 import { IProductCardData, IProductCardProps } from './ProductCard.type'
@@ -22,12 +23,12 @@ function ProductCard({ cardData, size }: IProductCardProps) {
     rating,
     reviewCount,
   }: IProductCardData = cardData
-  // const navigate = useNavigate()
+  const navigate = useNavigate()
 
   const handleClick = (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
     e.stopPropagation()
-    // navigate(`/products/${id}`)
-    window.location.replace(`/products/${id}`)
+    navigate(`/products/${id}`)
+    window.location.reload()
     registerRecentProducts(cardData)
   }
 

--- a/src/components/product-card/index.tsx
+++ b/src/components/product-card/index.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useState } from 'react'
 
 import star from '@/assets/home/empty-star.svg'
+import defaultImage from '@/assets/login/airplane.png'
 import { LOCALE_CODE_LIST } from '@/constants/FILTERING_BROWSING'
 import { registerRecentProducts } from '@/utils/registerLocalStorage'
 
@@ -13,7 +14,7 @@ import { IProductCardData, IProductCardProps } from './ProductCard.type'
 function ProductCard({ cardData, size }: IProductCardProps) {
   const {
     id,
-    imageUrl,
+    imageUrl = defaultImage,
     name,
     cityCode,
     address,

--- a/src/components/product-card/index.tsx
+++ b/src/components/product-card/index.tsx
@@ -6,7 +6,6 @@ import { LOCALE_CODE_LIST } from '@/constants/FILTERING_BROWSING'
 import { registerRecentProducts } from '@/utils/registerLocalStorage'
 
 import BookmarkButton from '@components/bookmark-button'
-import { useNavigate } from 'react-router-dom'
 
 import * as S from './ProductCard.style'
 import { IProductCardData, IProductCardProps } from './ProductCard.type'
@@ -23,11 +22,12 @@ function ProductCard({ cardData, size }: IProductCardProps) {
     rating,
     reviewCount,
   }: IProductCardData = cardData
-  const navigate = useNavigate()
+  // const navigate = useNavigate()
 
   const handleClick = (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
     e.stopPropagation()
-    navigate(`/products/${id}`)
+    // navigate(`/products/${id}`)
+    window.location.replace(`/products/${id}`)
     registerRecentProducts(cardData)
   }
 

--- a/src/pages/products-detail/components/recommend-card/index.tsx
+++ b/src/pages/products-detail/components/recommend-card/index.tsx
@@ -1,14 +1,13 @@
 import { useRef } from 'react'
 
 import useScrollHandlers from '@/hooks/useScrollHandlers'
-import { mockCard } from '@/pages/products-detail/mockData.ts'
 
 import ProductCard from '@components/product-card'
 import { IProductCardData } from '@components/product-card/ProductCard.type'
 
 import * as S from './RecommendCard.styles'
 
-const RecommendCard = ({ cards = mockCard }: { cards: IProductCardData[] }) => {
+const RecommendCard = ({ cards }: { cards: IProductCardData[] }) => {
   const recommendedProductsRef = useRef<HTMLDivElement>(null)
   const scrollRecommendedProductHandler = useScrollHandlers(
     recommendedProductsRef,

--- a/src/pages/products-detail/components/recommend-card/index.tsx
+++ b/src/pages/products-detail/components/recommend-card/index.tsx
@@ -1,13 +1,14 @@
 import { useRef } from 'react'
 
 import useScrollHandlers from '@/hooks/useScrollHandlers'
+import { mockCard } from '@/pages/products-detail/mockData.ts'
 
 import ProductCard from '@components/product-card'
 import { IProductCardData } from '@components/product-card/ProductCard.type'
 
 import * as S from './RecommendCard.styles'
 
-const RecommendCard = ({ cards }: { cards: IProductCardData[] }) => {
+const RecommendCard = ({ cards = mockCard }: { cards: IProductCardData[] }) => {
   const recommendedProductsRef = useRef<HTMLDivElement>(null)
   const scrollRecommendedProductHandler = useScrollHandlers(
     recommendedProductsRef,

--- a/src/pages/products-detail/components/review/Review.type.ts
+++ b/src/pages/products-detail/components/review/Review.type.ts
@@ -1,10 +1,10 @@
 export interface IReviewProps {
   reviewCnt: number
-  reviewImg: string[]
+  reviewImg?: string[]
   reviewData: IReviewData[]
   onOrderClick: () => void
   onEditClick: () => void
-  onPhotoReviewsClick: () => void
+  onPhotoReviewsClick?: () => void
 }
 
 export interface IReviewPageProps {

--- a/src/pages/products-detail/components/review/ReviewPage.tsx
+++ b/src/pages/products-detail/components/review/ReviewPage.tsx
@@ -26,11 +26,13 @@ const ReviewPage: React.FC<IReviewPageProps> = ({
         </S.ProfileNameWrapper>
       </S.ProfileHeader>
       <S.DescriptionWrapper>
-        <S.ReviewImgContainer>
-          <S.ReviewImg src={reviewData.image[0]} alt="리뷰 이미지" />
-          <S.ReviewImg src={reviewData.image[1]} alt="리뷰 이미지" />
-          <S.ReviewImg src={reviewData.image[2]} alt="리뷰 이미지" />
-        </S.ReviewImgContainer>
+        {reviewData.image.length > 0 && (
+          <S.ReviewImgContainer>
+            {reviewData.image.map((image) => (
+              <S.ReviewImg key={image} src={image} alt="리뷰 이미지" />
+            ))}
+          </S.ReviewImgContainer>
+        )}
         <S.BlackText>{reviewData.reviewText}</S.BlackText>
       </S.DescriptionWrapper>
       <S.LikeComment>

--- a/src/pages/products-detail/components/review/index.tsx
+++ b/src/pages/products-detail/components/review/index.tsx
@@ -14,7 +14,7 @@ const Review: React.FC<IReviewProps> = ({
   onEditClick,
   onPhotoReviewsClick,
 }) => {
-  const reviewImgCnt = reviewImg.length
+  const reviewImgCnt = reviewImg?.length
 
   return (
     <S.ReviewContainer>
@@ -42,14 +42,16 @@ const Review: React.FC<IReviewProps> = ({
             <S.IconSort src={sort} alt="정렬" />
           </S.SortWrapper>
         </S.ReviewCheckBox>
-        <S.ReviewImgContainer>
-          <S.ReviewImg src={reviewImg[0]} alt="리뷰 이미지" />
-          <S.ReviewImg src={reviewImg[1]} alt="리뷰 이미지" />
-          <S.LastReviewImg onClick={onPhotoReviewsClick}>
-            <S.ReviewImg src={reviewImg[2]} alt="리뷰 이미지" />
-            <S.ReviewImgBackground>+{reviewImgCnt - 2}</S.ReviewImgBackground>
-          </S.LastReviewImg>
-        </S.ReviewImgContainer>
+        {reviewImgCnt && (
+          <S.ReviewImgContainer>
+            <S.ReviewImg src={reviewImg[0]} alt="리뷰 이미지" />
+            <S.ReviewImg src={reviewImg[1]} alt="리뷰 이미지" />
+            <S.LastReviewImg onClick={onPhotoReviewsClick}>
+              <S.ReviewImg src={reviewImg[2]} alt="리뷰 이미지" />
+              <S.ReviewImgBackground>+{reviewImgCnt - 2}</S.ReviewImgBackground>
+            </S.LastReviewImg>
+          </S.ReviewImgContainer>
+        )}
       </S.ReviewHeader>
       {reviewData.map((data: IReviewData) => (
         <ReviewPage

--- a/src/pages/products-detail/components/review/index.tsx
+++ b/src/pages/products-detail/components/review/index.tsx
@@ -44,12 +44,22 @@ const Review: React.FC<IReviewProps> = ({
         </S.ReviewCheckBox>
         {reviewImgCnt && (
           <S.ReviewImgContainer>
-            <S.ReviewImg src={reviewImg[0]} alt="리뷰 이미지" />
-            <S.ReviewImg src={reviewImg[1]} alt="리뷰 이미지" />
-            <S.LastReviewImg onClick={onPhotoReviewsClick}>
-              <S.ReviewImg src={reviewImg[2]} alt="리뷰 이미지" />
-              <S.ReviewImgBackground>+{reviewImgCnt - 2}</S.ReviewImgBackground>
-            </S.LastReviewImg>
+            {reviewImgCnt <= 3 ? (
+              reviewImg.map((photo) => (
+                <S.ReviewImg key={photo} src={photo} alt="리뷰 이미지" />
+              ))
+            ) : (
+              <>
+                <S.ReviewImg src={reviewImg[0]} alt="리뷰 이미지" />
+                <S.ReviewImg src={reviewImg[1]} alt="리뷰 이미지" />
+                <S.LastReviewImg onClick={onPhotoReviewsClick}>
+                  <S.ReviewImg src={reviewImg[2]} alt="리뷰 이미지" />
+                  <S.ReviewImgBackground>
+                    +{reviewImgCnt - 2}
+                  </S.ReviewImgBackground>
+                </S.LastReviewImg>
+              </>
+            )}
           </S.ReviewImgContainer>
         )}
       </S.ReviewHeader>

--- a/src/pages/products-detail/index.tsx
+++ b/src/pages/products-detail/index.tsx
@@ -127,7 +127,11 @@ function ProductsDetail() {
           website={homepage}
         />
         <Description />
-        <RecommendCard cards={recommendProductData || mockCard} />
+        <RecommendCard
+          cards={
+            recommendProductData?.length > 0 ? recommendProductData : mockCard
+          }
+        />
         <Review
           reviewCnt={reviewCount}
           reviewImg={reviewImg}

--- a/src/pages/products-detail/index.tsx
+++ b/src/pages/products-detail/index.tsx
@@ -17,7 +17,7 @@ import Info from './components/info'
 import RecommendCard from './components/recommend-card'
 import Review from './components/review'
 import SheetRenderer from './components/sheet-renderer'
-import { reviewData as const_review_data } from './mockData'
+import { mockCard, reviewData as const_review_data } from './mockData'
 import * as S from './ProductsDetail.style'
 
 import type { ISheetComponents } from './ProductsDetail.type'
@@ -26,10 +26,11 @@ import { IProductCardData } from '@components/product-card/ProductCard.type.ts'
 
 function ProductsDetail() {
   const { productId } = useParams()
-  const { data: productDetailQuery } = useQuery({
-    queryKey: ['products-detail', productId],
-    queryFn: ({ queryKey }) => getProductDetail(Number(queryKey[1])),
-  })
+  const { data: productDetailQuery, isSuccess: isProductDetailSuccess } =
+    useQuery({
+      queryKey: ['products-detail', productId],
+      queryFn: ({ queryKey }) => getProductDetail(Number(queryKey[1])),
+    })
   const {
     address = '',
     cityCode = '',
@@ -49,12 +50,11 @@ function ProductsDetail() {
     keyword: address.split(' ')[1],
     cityCode: cityCode,
   }
-
   const { data: recommendProductQuery } = useQuery({
     queryKey: ['recommend-products'],
     queryFn: () => getSearchProducts(recommendQueryData),
+    enabled: isProductDetailSuccess,
   })
-
   const recommendProductData = recommendProductQuery?.data.content.filter(
     (product: IProductCardData) => product.id.toString() !== productId,
   )
@@ -127,7 +127,7 @@ function ProductsDetail() {
           website={homepage}
         />
         <Description />
-        <RecommendCard cards={recommendProductData} />
+        <RecommendCard cards={recommendProductData || mockCard} />
         <Review
           reviewCnt={reviewCount}
           reviewImg={reviewImg}

--- a/src/pages/products-detail/index.tsx
+++ b/src/pages/products-detail/index.tsx
@@ -17,7 +17,7 @@ import Info from './components/info'
 import RecommendCard from './components/recommend-card'
 import Review from './components/review'
 import SheetRenderer from './components/sheet-renderer'
-import { mockCard, mockData3, reviewData } from './mockData'
+import { mockCard, reviewData as const_review_data } from './mockData'
 import * as S from './ProductsDetail.style'
 
 import type { ISheetComponents } from './ProductsDetail.type'
@@ -66,7 +66,13 @@ function ProductsDetail() {
     dispatch(sheet({ name: 'photo-reviews-sheet', status: true, text: '' }))
   }
 
-  if (isPhotoReviewsSheet) return <PhotoReviewsSheet reviewImg={mockData3} />
+  const reviewData = const_review_data
+  const reviewImg = reviewData?.reduce(
+    (acc: string[], review) => acc.concat(review.image),
+    [],
+  )
+
+  if (isPhotoReviewsSheet) return <PhotoReviewsSheet reviewImg={reviewImg} />
 
   const shareSheetProps = {
     address: address,
@@ -106,8 +112,8 @@ function ProductsDetail() {
         <RecommendCard cards={mockCard} />
         <Review
           reviewCnt={reviewCount}
-          reviewImg={mockData3}
-          reviewData={reviewData}
+          reviewImg={reviewImg}
+          reviewData={const_review_data}
           onOrderClick={() => handleSheetDispatch('review-order-sheet')}
           onEditClick={() => handleSheetDispatch('edit-sheet')}
           onPhotoReviewsClick={handlePhotoReviewsClick}

--- a/src/pages/products-detail/mockData.ts
+++ b/src/pages/products-detail/mockData.ts
@@ -59,11 +59,7 @@ export const mockData3 = [
 
 export const reviewData = [
   {
-    image: [
-      'https://img-cdn.pixlr.com/image-generator/history/65bb506dcb310754719cf81f/ede935de-1138-4f66-8ed7-44bd16efc709/medium.webp',
-      'https://images.unsplash.com/photo-1575936123452-b67c3203c357?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8aW1hZ2V8ZW58MHx8MHx8fDA%3D',
-      'https://img.freepik.com/free-photo/painting-mountain-lake-with-mountain-background_188544-9126.jpg',
-    ],
+    image: [],
     name: '사용자1',
     profileImage:
       'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885_1280.jpg',


### PR DESCRIPTION
## #️⃣ PR 타입

- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정(디자인 등)

## 📝 작업 내용/변경 사항
📌 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) 
> - product card 이미지가 불러와지지 않을 때 표시할 default image 추가
> - 기존 리뷰 UI 구현 시 리뷰 이미지를 따로 불러오던 부분 reviewData와 연동하여 사용할 수 있도록 수정
> - 리뷰 이미지가 없는 경우를 고려하여 타입, 옵셔널 렌더링 등 수정 + 사진 리뷰가 3개를 넘지 않을 때 처리
> - 추천 상품 기능 구현 : 이전에 회의를 통해 논의했던(주소 검색) 로직으로 구현

### 스크린샷 (선택)
| 기능 | 스크린샷 |
| --- | --- |
| '남이섬' 페이지, 같은 춘천에 있는 레고랜드가 표시 | <img src = "https://github.com/travelly-8/travelly-fe/assets/40304565/f7c8d718-6e9c-4fcc-a5a4-a482a4b0c9f7" width ="250">  |
| default image | <img src = "https://github.com/travelly-8/travelly-fe/assets/40304565/4e27ddee-b100-4b2f-9e84-326c5eee0d47" width ="250">  |
| 사진이 없는 리뷰 | <img src = "https://github.com/travelly-8/travelly-fe/assets/40304565/8c0a052e-b2f2-42f6-815d-d4d5193b1fa7" width ="250">  |

## 💬 리뷰 요구사항(선택)
📌 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - 검색 결과가 나타나지 않을 때 어떤 상품들을 띄울 지 논의가 필요합니다.
> - 추천 상품을 클릭했을 때 해당 상품 페이지로 이동이 되는데, 클릭  시점 위치에서 그대로 있어서 이동이 되었는지 잘 알아채기가 어렵습니다. 그래서 navigate로 이동할 때 reload를 한 번 하도록 추가해두었는데, 더 좋은 방법 있다면 공유해주세요!

##  💭 연관된 이슈(선택)
📌 #이슈번호
