### PR TITLE
예약 페이지 api연동 및 예약 페이지 기능 추가

### DIFF
--- a/src/components/check-box/index.tsx
+++ b/src/components/check-box/index.tsx
@@ -4,12 +4,14 @@ interface ICheckBoxProps {
   text: string
   defaultChecked?: boolean
   disabled?: boolean
+  onChange?: (isChecked: boolean) => void
 }
 
 function CheckBox({
   text,
   defaultChecked = false,
   disabled = false,
+  onChange,
 }: ICheckBoxProps) {
   return (
     <S.Label>
@@ -17,6 +19,7 @@ function CheckBox({
         type="checkbox"
         defaultChecked={defaultChecked}
         disabled={disabled}
+        onChange={(e) => onChange?.(e.target.checked)}
       />
       <S.Text>{text}</S.Text>
     </S.Label>

--- a/src/components/footer-reservation/FooterReservation.type.ts
+++ b/src/components/footer-reservation/FooterReservation.type.ts
@@ -10,4 +10,5 @@ export interface IFooter extends IButtonType {
   productId?: string
   onPayConfirmClick?: () => void
   onPayCancelClick?: () => void
+  onSubmit?: () => void
 }

--- a/src/components/footer-reservation/index.tsx
+++ b/src/components/footer-reservation/index.tsx
@@ -21,6 +21,7 @@ const FooterReservation = ({
   productId,
   onPayConfirmClick,
   onPayCancelClick,
+  onSubmit,
 }: IFooter) => {
   const navigate = useNavigate()
   const [isBookmarked, setIsBookmarked] = useState(initialBookmarked)
@@ -28,7 +29,8 @@ const FooterReservation = ({
   const handleButtonClick = () => {
     if (buttontype === 'reservation') {
       navigate(`/reservation/${productId}`)
-    } else if (buttontype === 'payment' && onPayConfirmClick) {
+    } else if (buttontype === 'payment' && onPayConfirmClick && onSubmit) {
+      onSubmit()
       onPayConfirmClick()
     } else if (buttontype === 'cancelPayment' && onPayCancelClick) {
       onPayCancelClick()
@@ -51,7 +53,7 @@ const FooterReservation = ({
           {isReservationProduct && (
             <S.Text>
               <S.DiscountText>{discount}%</S.DiscountText>
-              <S.PriceText>{price?.toLocaleString('ko-KR')}원</S.PriceText>
+              <S.PriceText>{price?.toLocaleString('ko-KR')} 포인트</S.PriceText>
             </S.Text>
           )}
           <RoundButton.Primary onClick={handleButtonClick}>

--- a/src/pages/reservation/components/cancellation-policy/index.tsx
+++ b/src/pages/reservation/components/cancellation-policy/index.tsx
@@ -2,7 +2,13 @@ import CheckBox from '@components/check-box'
 
 import * as S from './CancellationPolicy.style'
 
-function CancellationPolicy() {
+interface ICancellationPolicyProps {
+  setCancellationPolicyChecked: (isChecked: boolean) => void
+}
+
+function CancellationPolicy({
+  setCancellationPolicyChecked,
+}: ICancellationPolicyProps) {
   return (
     <S.SectionWrapper>
       <S.PolicyHeader>취소 및 환불 규정 확인하기</S.PolicyHeader>
@@ -13,7 +19,10 @@ function CancellationPolicy() {
         <S.SecondPolicy>예약 기간이 0일 전까지 취소 가능합니다.</S.SecondPolicy>
       </S.Policy>
       <S.CheckConsent>
-        <CheckBox text="취소 및 환불 규정에 동의합니다." />
+        <CheckBox
+          text="취소 및 환불 규정에 동의합니다."
+          onChange={setCancellationPolicyChecked}
+        />
       </S.CheckConsent>
     </S.SectionWrapper>
   )

--- a/src/pages/reservation/components/cancellation-policy/index.tsx
+++ b/src/pages/reservation/components/cancellation-policy/index.tsx
@@ -3,7 +3,7 @@ import CheckBox from '@components/check-box'
 import * as S from './CancellationPolicy.style'
 
 interface ICancellationPolicyProps {
-  setCancellationPolicyChecked: (isChecked: boolean) => void
+  setCancellationPolicyChecked?: (isChecked: boolean) => void
 }
 
 function CancellationPolicy({

--- a/src/pages/reservation/components/reservation-input/Reservation.type.ts
+++ b/src/pages/reservation/components/reservation-input/Reservation.type.ts
@@ -6,12 +6,12 @@ import {
 } from 'react-hook-form'
 
 export interface IReservationInputProps {
-  nameRegister: UseFormRegisterReturn
-  phoneRegister: UseFormRegisterReturn
-  emailRegister: UseFormRegisterReturn
-  errors: FieldErrors
-  handleSubmit: UseFormHandleSubmit<IReservationInputState>
-  onSubmit: SubmitHandler<IReservationInputState>
+  nameRegister?: UseFormRegisterReturn
+  phoneRegister?: UseFormRegisterReturn
+  emailRegister?: UseFormRegisterReturn
+  errors?: FieldErrors
+  handleSubmit?: UseFormHandleSubmit<IReservationInputState>
+  onSubmit?: SubmitHandler<IReservationInputState>
   disabled?: boolean
 }
 

--- a/src/pages/reservation/components/reservation-input/Reservation.type.ts
+++ b/src/pages/reservation/components/reservation-input/Reservation.type.ts
@@ -1,6 +1,18 @@
+import {
+  FieldErrors,
+  SubmitHandler,
+  UseFormHandleSubmit,
+  UseFormRegisterReturn,
+} from 'react-hook-form'
+
 export interface IReservationInputProps {
+  nameRegister: UseFormRegisterReturn
+  phoneRegister: UseFormRegisterReturn
+  emailRegister: UseFormRegisterReturn
+  errors: FieldErrors
+  handleSubmit: UseFormHandleSubmit<IReservationInputState>
+  onSubmit: SubmitHandler<IReservationInputState>
   disabled?: boolean
-  // 나중에 regiseter를 props로 받아서 사용할 수 있음 + defaultValues도
 }
 
 export interface IReservationInputState {

--- a/src/pages/reservation/components/reservation-input/index.tsx
+++ b/src/pages/reservation/components/reservation-input/index.tsx
@@ -1,22 +1,15 @@
-import { useForm } from 'react-hook-form'
-
-import {
-  IReservationInputProps,
-  IReservationInputState,
-} from './Reservation.type'
+import { IReservationInputProps } from './Reservation.type'
 import * as S from './ReservationInput.style'
 
 const ReservationInput: React.FC<IReservationInputProps> = ({
+  nameRegister,
+  phoneRegister,
+  emailRegister,
+  errors,
+  handleSubmit,
+  onSubmit,
   disabled = false,
 }) => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<IReservationInputState>()
-  const onSubmit = (data: IReservationInputState) => {
-    console.log(data) // 나중에 수정
-  }
   const defaultValues = {
     name: '홍길동',
     phone: '01012345678',
@@ -29,7 +22,7 @@ const ReservationInput: React.FC<IReservationInputProps> = ({
         <S.InputWrapper>
           <S.Label>예약자명</S.Label>
           <S.Input
-            {...register('name', { required: '예약자명을 입력해주세요' })}
+            {...nameRegister}
             type="text"
             placeholder="예약자명"
             defaultValue={disabled ? defaultValues.name : undefined}
@@ -40,13 +33,7 @@ const ReservationInput: React.FC<IReservationInputProps> = ({
         <S.InputWrapper>
           <S.Label>연락처</S.Label>
           <S.Input
-            {...register('phone', {
-              required: '연락처를 입력해주세요',
-              pattern: {
-                value: /^[0-9\b -]{7,13}$/,
-                message: '올바른 연락처 형식을 입력해주세요',
-              },
-            })}
+            {...phoneRegister}
             type="tel"
             placeholder="연락처"
             defaultValue={disabled ? defaultValues.phone : undefined}
@@ -57,13 +44,7 @@ const ReservationInput: React.FC<IReservationInputProps> = ({
         <S.InputWrapper>
           <S.Label>이메일</S.Label>
           <S.Input
-            {...register('email', {
-              required: '이메일을 입력해주세요',
-              pattern: {
-                value: /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/,
-                message: '올바른 이메일 형식을 입력해주세요',
-              },
-            })}
+            {...emailRegister}
             type="text"
             placeholder="이메일"
             defaultValue={disabled ? defaultValues.email : undefined}

--- a/src/pages/reservation/components/reservation-input/index.tsx
+++ b/src/pages/reservation/components/reservation-input/index.tsx
@@ -16,8 +16,17 @@ const ReservationInput: React.FC<IReservationInputProps> = ({
     email: 'abcd@naver.com',
   }
   const nameProps = { disabled, defaultValue: defaultValues.name }
+
+  const preventDefaultSubmit = (event: React.FormEvent) => {
+    event.preventDefault() //reservation-detail일때는 이벤트가 발생하지 않도록 설정
+  }
   return (
-    <form onSubmit={handleSubmit(onSubmit)} style={{ width: '100%' }}>
+    <form
+      onSubmit={
+        handleSubmit && onSubmit ? handleSubmit(onSubmit) : preventDefaultSubmit
+      }
+      style={{ width: '100%' }}
+    >
       <S.InputContainer>
         <S.InputWrapper>
           <S.Label>예약자명</S.Label>
@@ -28,7 +37,7 @@ const ReservationInput: React.FC<IReservationInputProps> = ({
             defaultValue={disabled ? defaultValues.name : undefined}
             disabled={disabled}
           />
-          {errors.name && <S.Error>{errors.name.message as string}</S.Error>}
+          {errors?.name && <S.Error>{errors.name.message as string}</S.Error>}
         </S.InputWrapper>
         <S.InputWrapper>
           <S.Label>연락처</S.Label>
@@ -39,7 +48,7 @@ const ReservationInput: React.FC<IReservationInputProps> = ({
             defaultValue={disabled ? defaultValues.phone : undefined}
             disabled={disabled}
           />
-          {errors.phone && <S.Error>{errors.phone.message as string}</S.Error>}
+          {errors?.phone && <S.Error>{errors.phone.message as string}</S.Error>}
         </S.InputWrapper>
         <S.InputWrapper>
           <S.Label>이메일</S.Label>
@@ -50,7 +59,7 @@ const ReservationInput: React.FC<IReservationInputProps> = ({
             defaultValue={disabled ? defaultValues.email : undefined}
             disabled={disabled}
           />
-          {errors.email && <S.Error>{errors.email.message as string}</S.Error>}
+          {errors?.email && <S.Error>{errors.email.message as string}</S.Error>}
         </S.InputWrapper>
       </S.InputContainer>
     </form> // 버튼은 작동 확인 위한 임시버튼

--- a/src/pages/reservation/components/ticket-count-section/index.tsx
+++ b/src/pages/reservation/components/ticket-count-section/index.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+
+import { personnel } from '@/store/personnel-slice/personnel-slice'
+
+import { useDispatch } from 'react-redux'
 
 import * as S from './TicketCountSection.style'
-
 const mockTicket = ['성인', '청소년', '소아']
 
 interface ITicketCounts {
@@ -9,6 +12,8 @@ interface ITicketCounts {
 }
 
 function TicketCountSection({ isInput = true }: { isInput: boolean }) {
+  const dispatch = useDispatch()
+
   const initialCounts: ITicketCounts = mockTicket.reduce((acc, ticketType) => {
     acc[ticketType] = 0
     return acc
@@ -29,6 +34,16 @@ function TicketCountSection({ isInput = true }: { isInput: boolean }) {
       [ticketType]: Math.max(prevCounts[ticketType] - 1, 0),
     }))
   }
+
+  useEffect(() => {
+    dispatch(
+      personnel({
+        adult: ticketCounts['성인'],
+        teenager: ticketCounts['청소년'],
+        infant: ticketCounts['소아'],
+      }),
+    )
+  }, [ticketCounts])
 
   return (
     <S.SectionWrapper>

--- a/src/pages/reservation/reserve/index.tsx
+++ b/src/pages/reservation/reserve/index.tsx
@@ -61,6 +61,12 @@ function ReservationPage() {
     !/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(emailValue)
   const dispatch = useDispatch()
   const [isRadioChecked, setIsRadioChecked] = useState(true)
+  const [isCancelPolicyChecked, setIsCancelPolicyChecked] = useState(false)
+
+  const handleSetCancellationPolicyChecked = (isChecked: boolean) => {
+    setIsCancelPolicyChecked(isChecked)
+  }
+
   const { productId } = useParams()
 
   const { data: productDetail } = useQuery({
@@ -76,9 +82,8 @@ function ReservationPage() {
     },
     [dispatch, isError],
   )
-
   const handlePayConfirmClick = () => {
-    if (!isError) {
+    if (!isError && isCancelPolicyChecked) {
       handleSheetDispatch('pay-confirm-sheet')
     } else {
       dispatch(sheet({ name: 'pay-confirm-sheet', status: false, text: '' }))
@@ -90,8 +95,10 @@ function ReservationPage() {
   )
 
   const ticketPrice =
-    ticketDto[0]?.price *
-    (personnel.adult + personnel.teenager + personnel.infant) // 나중에 성인 청소년 소아 나눠지면 변경
+    ticketDto && ticketDto.length > 0
+      ? ticketDto[0].price *
+        (personnel.adult + personnel.teenager + personnel.infant)
+      : 0 // 나중에 성인 청소년 소아 나눠지면 변경
 
   const handleRadioChange = () => {
     setIsRadioChecked(!isRadioChecked)
@@ -164,7 +171,9 @@ function ReservationPage() {
           </S.AllPayTitle>
           <S.AllAmount>{ticketPrice} 포인트</S.AllAmount>
         </S.PayAmount>
-        <CancellationPolicy />
+        <CancellationPolicy
+          setCancellationPolicyChecked={handleSetCancellationPolicyChecked}
+        />
       </S.PageContainer>
       <FooterReservation
         isBookmarked={true}

--- a/src/pages/reservation/reserve/index.tsx
+++ b/src/pages/reservation/reserve/index.tsx
@@ -1,31 +1,97 @@
 import { useCallback, useState } from 'react'
 
+import { getProductDetail } from '@/api/productsAPI'
 import SheetRenderer from '@/pages/products-detail/components/sheet-renderer'
 import { ISheetComponents } from '@/pages/products-detail/ProductsDetail.type'
 import CancellationPolicy from '@/pages/reservation/components/cancellation-policy'
 import ReservationDateSection from '@/pages/reservation/components/reservation-date-section'
 import ReservationInput from '@/pages/reservation/components/reservation-input'
+import type { IReservationInputState } from '@/pages/reservation/components/reservation-input/Reservation.type'
 import type { IPaySheet } from '@/pages/reservation/components/sheet/PaySheet.type'
 import TicketCountSection from '@/pages/reservation/components/ticket-count-section'
+import { IPersonnelSliceState } from '@/store/personnel-slice/personnel-slice.type'
 import { sheet } from '@/store/sheet-slice/sheet-slice'
 
 import CheckBox from '@components/check-box'
 import FooterReservation from '@components/footer-reservation'
 import PageHeader from '@components/page-header'
-import { useDispatch } from 'react-redux'
+import ReviewProductCard from '@components/review-product-card'
+import { useQuery } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import { useDispatch, useSelector } from 'react-redux'
+import { useParams } from 'react-router-dom'
 
 import * as S from './ReservationPage.style'
 
 function ReservationPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<IReservationInputState>()
+  const onSubmit = (data: IReservationInputState) => {
+    console.log(data) // 나중에 용도에 맞게 변경
+  }
+
+  const nameRegister = register('name', { required: '예약자명을 입력해주세요' })
+  const phoneRegister = register('phone', {
+    required: '연락처를 입력해주세요',
+    pattern: {
+      value: /^[0-9\b -]{7,13}$/,
+      message: '올바른 연락처 형식을 입력해주세요',
+    },
+  })
+  const emailRegister = register('email', {
+    required: '이메일을 입력해주세요',
+    pattern: {
+      value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      message: '올바른 이메일 형식을 입력해주세요',
+    },
+  })
+
+  const nameValue = watch('name')
+  const phoneValue = watch('phone')
+  const emailValue = watch('email')
+
+  const isNameValid = !nameValue
+  const isPhoneValid = !phoneValue || !/^[0-9\b -]{7,13}$/.test(phoneValue)
+  const isEmailValid =
+    !emailValue ||
+    !/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(emailValue)
   const dispatch = useDispatch()
   const [isRadioChecked, setIsRadioChecked] = useState(true)
+  const { productId } = useParams()
 
+  const { data: productDetail } = useQuery({
+    queryKey: ['products-detail', productId],
+    queryFn: ({ queryKey }) => getProductDetail(Number(queryKey[1])),
+  })
+
+  const { name, images, ticketDto } = productDetail?.data || {} // merge되면 변경
+  const isError = isNameValid || isPhoneValid || isEmailValid
   const handleSheetDispatch = useCallback(
     (name: keyof ISheetComponents) => {
       dispatch(sheet({ name, status: true, text: '' }))
     },
-    [dispatch],
+    [dispatch, isError],
   )
+
+  const handlePayConfirmClick = () => {
+    if (!isError) {
+      handleSheetDispatch('pay-confirm-sheet')
+    } else {
+      dispatch(sheet({ name: 'pay-confirm-sheet', status: false, text: '' }))
+    }
+  }
+
+  const personnel = useSelector(
+    (state: IPersonnelSliceState) => state.personnel.value,
+  )
+
+  const ticketPrice =
+    ticketDto[0]?.price *
+    (personnel.adult + personnel.teenager + personnel.infant) // 나중에 성인 청소년 소아 나눠지면 변경
 
   const handleRadioChange = () => {
     setIsRadioChecked(!isRadioChecked)
@@ -36,19 +102,37 @@ function ReservationPage() {
     productPoint: 1000,
   }
 
+  const reviewProductCardProps = {
+    id: productId,
+    name: name,
+    images: images,
+    createdDate: '24.00.00-24.00.00',
+    ticketDto: ticketDto,
+  }
+
   return (
     <>
       <PageHeader>
         <S.HeaderTitle>상품 예약하기</S.HeaderTitle>
       </PageHeader>
       <S.PageContainer>
-        {/* <S.CardWrapper>
-          <ReviewProductCard />
-        </S.CardWrapper> */}
+        <S.CardWrapper>
+          <ReviewProductCard
+            productDetail={reviewProductCardProps}
+            isCommentMode={false}
+          />
+        </S.CardWrapper>
         <S.CheckBoxWrapper>
           <CheckBox text="계정정보 가져오기" />
         </S.CheckBoxWrapper>
-        <ReservationInput />
+        <ReservationInput
+          nameRegister={nameRegister}
+          phoneRegister={phoneRegister}
+          emailRegister={emailRegister}
+          errors={errors}
+          handleSubmit={handleSubmit}
+          onSubmit={onSubmit}
+        />
         <S.TicketInfo>
           <TicketCountSection isInput />
           <ReservationDateSection
@@ -78,17 +162,18 @@ function ReservationPage() {
             <S.AllPayText>총 결제 금액</S.AllPayText>
             <S.Vat>(VAT포함)</S.Vat>
           </S.AllPayTitle>
-          <S.AllAmount>1,000,000원</S.AllAmount>
+          <S.AllAmount>{ticketPrice} 포인트</S.AllAmount>
         </S.PayAmount>
         <CancellationPolicy />
       </S.PageContainer>
       <FooterReservation
         isBookmarked={true}
         isReservationProduct={true}
-        price={0}
+        price={ticketPrice}
         discount={0}
         buttontype="payment"
-        onPayConfirmClick={() => handleSheetDispatch('pay-confirm-sheet')}
+        onPayConfirmClick={handlePayConfirmClick}
+        onSubmit={handleSubmit(onSubmit)}
       />
       <SheetRenderer payConfirmProps={payConfirmProps} />
     </>

--- a/src/store/personnel-slice/personnel-slice.ts
+++ b/src/store/personnel-slice/personnel-slice.ts
@@ -1,0 +1,15 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+export const personnelSlice = createSlice({
+  name: 'personnel',
+  initialState: { value: { adult: 0, teenager: 0, infant: 0 } },
+  reducers: {
+    personnel: (state, action) => {
+      state.value = action.payload
+    },
+    reset: () => {},
+  },
+})
+
+export const { personnel, reset } = personnelSlice.actions
+export default personnelSlice.reducer

--- a/src/store/personnel-slice/personnel-slice.type.ts
+++ b/src/store/personnel-slice/personnel-slice.type.ts
@@ -1,0 +1,9 @@
+export interface IPersonnelSliceState {
+  personnel: {
+    value: {
+      adult: number
+      teenager: number
+      infant: number
+    }
+  }
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -13,6 +13,7 @@ import storage from 'redux-persist/lib/storage'
 
 import authReducer from './auth-slice/auth-slice'
 import commentReducer from './comment-slice/comment-slice'
+import personnelReducer from './personnel-slice/personnel-slice'
 import productReducer from './product-slice/product-slice'
 import { sheetSlice } from './sheet-slice/sheet-slice'
 
@@ -21,12 +22,13 @@ const rootReducer = combineReducers({
   sheet: sheetSlice.reducer,
   product: productReducer,
   comment: commentReducer,
+  personnel: personnelReducer,
 })
 
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['auth', 'sheet', 'product'],
+  whitelist: ['auth', 'sheet', 'product', 'personnel'],
 }
 
 const persistedReducer = persistReducer(persistConfig, rootReducer)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from 'vite'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 1000, // npm run build 오류 해결
+  },
   resolve: {
     alias: [
       { find: '@components', replacement: '/src/components' },


### PR DESCRIPTION
## #️⃣ PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정(디자인 등)

## 📝 작업 내용/변경 사항
📌 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) 
> - 예약 페이지 api연동
> - 인원 설정마다 포인트 값 안내 변경
> - input값 설정 제대로 안하거나 환불 규정 동의 안할시 결제 시트 안띄우게 변경

### 스크린샷 (선택)
| 기능 | 스크린샷 |
| --- | --- |
|  | <img src = "" width ="250">  |
![예약 페이지](https://github.com/travelly-8/travelly-fe/assets/151784621/c698ea29-665a-40ee-9300-a2fd8385abaa)


## 💬 리뷰 요구사항(선택)
📌 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - 추후 예약 일정 관련 review카드 쪽 변경 에정 현재는 Invalid date라 뜸
> - 예약 날짜 관련해서도 수정 예정
> -  추후 ticketDto 값이 성인 청소년 소아 나눠지면 관련 로직도 수정 예정
> - 계정 정보 가져오기 로그인시 정보들 localstorage에다가 저장 할지 상의 필요

##  💭 연관된 이슈(선택)
📌 #이슈번호
#203