### PR TITLE
reissue 에러 해결

### DIFF
--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react'
+
+import { getLogout } from '@/api/authAPI'
+import { clearUser } from '@/store/auth-slice/auth-slice'
+import { deleteTokens } from '@/utils/tokenStorage'
+
+import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+
+const useLogout = () => {
+  const dispatch = useDispatch()
+  const navigate = useNavigate()
+
+  const logout = useCallback(async () => {
+    try {
+      await getLogout()
+      deleteTokens()
+      dispatch(clearUser())
+      sessionStorage.removeItem('relogin')
+      navigate('/')
+    } catch (err) {
+      console.error(err)
+    }
+  }, [dispatch, navigate])
+
+  return logout
+}
+
+export default useLogout

--- a/src/pages/mypage/edit/index.tsx
+++ b/src/pages/mypage/edit/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 
-import { getLogout } from '@/api/authAPI'
 import {
   getMemberProfile,
   putMemberNickname,
@@ -14,11 +13,10 @@ import logoutSvg from '@/assets/mypage/logout.svg'
 import purplePenSvg from '@/assets/mypage/purple-pen.svg'
 import { API_MEMBER } from '@/constants/API'
 import useGetMemberProfile from '@/hooks/api/memberAPI/useGetMemberProfile'
+import useLogout from '@/hooks/useLogout'
 import EditPasswordPage from '@/pages/mypage/components/edit-password'
-import { clearUser } from '@/store/auth-slice/auth-slice'
 import { sheet } from '@/store/sheet-slice/sheet-slice'
 import { ISheetSliceState } from '@/store/sheet-slice/sheet-slice.type'
-import { deleteTokens } from '@/utils/tokenStorage'
 
 import BlurSheet from '@components/blur-sheet'
 import BottomSheet from '@components/bottom-sheet'
@@ -33,6 +31,7 @@ import * as S from './MyPageEditPage.style'
 export default function MyPageEditPage() {
   const navigate = useNavigate()
   const dispatch = useDispatch()
+  const logout = useLogout()
   const sheetReducer = useSelector(
     (state: ISheetSliceState) => state.sheet.value,
   )
@@ -53,17 +52,7 @@ export default function MyPageEditPage() {
       id: 2,
       icon: logoutSvg,
       text: '로그아웃',
-      onClick: () => {
-        getLogout()
-          .then(() => {
-            deleteTokens()
-            dispatch(clearUser())
-            navigate('/')
-          })
-          .catch((err) => {
-            console.error(err)
-          })
-      },
+      onClick: () => logout(),
     },
   ]
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,7 +1,10 @@
+import { useEffect } from 'react'
+
 import bubble from '@/assets/signup/bubble.png'
 import google from '@/assets/signup/google.png'
 import naver from '@/assets/signup/naver.svg'
 import signup from '@/assets/signup/signup.png'
+import useLogout from '@/hooks/useLogout'
 
 import PageHeader from '@components/page-header'
 import RectangleButton from '@components/rectangle-button'
@@ -11,6 +14,7 @@ import * as S from './SignupStartPage.style'
 
 export default function SignupStartPage() {
   const navigate = useNavigate()
+  const logout = useLogout()
 
   const handleNaverLogin = () => {
     const clientId = 'Ka9kJLyk9psbYa8p1OGf'
@@ -31,6 +35,12 @@ export default function SignupStartPage() {
     const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=${clientId}&redirect_uri=${redirectURI}&scope=profile email`
     window.location.href = googleAuthUrl
   }
+
+  useEffect(() => {
+    const isRelogin = sessionStorage.getItem('relogin')
+
+    isRelogin && logout()
+  }, [])
 
   return (
     <>

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -25,7 +25,15 @@ export const refreshAccessToken = async () => {
     saveTokens(newAccessToken, refreshToken)
     return newAccessToken
   } catch (error) {
-    throw new Error('Failed to refresh access token')
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        alert('다시 로그인해주세요!')
+        sessionStorage.setItem('relogin', 'true')
+        window.location.pathname = '/signup/start'
+      }
+    } else {
+      console.error('Unexpected error', error)
+    }
   }
 }
 


### PR DESCRIPTION
## #️⃣ PR 타입

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정(디자인 등)

## 📝 작업 내용/변경 사항
📌 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) 
> - #248 
> - 로그아웃 로직 커스텀 훅으로 분리
> -

### reissue 안되던 문제 원인

- 현재 accessToken과 refreshToken을 사용해서 유저의 로그인 상태를 관리하고 있습니다. 이 때 발생할 수 있는 케이스는 아래와 같습니다.
  1. accessToken 유효, refreshToken 유효 -> 정상 작동
  2. accessToken 만료, refreshToken 유효 -> accessToken 재발급  w/ refreshToken
  3. accessToken 유효, refreshToken 만료 -> 아직 accessToken은 유효하므로, 유저는 문제없이 데이터에 접근 가능
  4. accessToken 만료, refreshToken 만료 -> refreshToken으로 accessToken을 재발급 받을 때, 이미 refreshToken도 만료되었으므로 서버에서는 401 에러를 줌 
- 지난 번에 고친 부분은 2번 케이스에 대한 부분이었고, 아직 에러가 남아있었던 부분은 4번 케이스라고 추정되었습니다
- 원준님께 물어보니, 현재 refreshToken의 기간이 1시간으로 짧아서, 이를 늘리고 refreshToken이 만료되면 사용자를 강제 로그아웃 시키는 방법으로 처리하기로 했습니다

### 스크린샷 (선택)
| 기능 | 스크린샷 |
| --- | --- |
|  | <img src = "" width ="250">  |


## 💬 리뷰 요구사항(선택)
📌 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - 혹시 또 에러가 뜬다면 (설마..) 이슈 리오픈해주시고 저한테 알려주세요!! 🔥 
> -

##  💭 연관된 이슈(선택)
📌 #이슈번호
